### PR TITLE
fix: process public keys from Mastodon servers that a in a different structure

### DIFF
--- a/src/apkit/helper/inbox.py
+++ b/src/apkit/helper/inbox.py
@@ -46,7 +46,11 @@ class InboxVerifier:
         keys = {}
         if isinstance(actor.publicKey, CryptographicKey):
             keys[actor.publicKey.id] = actor.publicKey.publicKeyPem
-        elif "publicKeyPem" in actor.publicKey:
+        elif (
+            isinstance(actor.publicKey, dict)
+            and "id" in actor.publicKey
+            and "publicKeyPem" in actor.publicKey
+        ):
             keys[actor.publicKey["id"]] = actor.publicKey["publicKeyPem"]
         if actor.assertionMethod:
             for method in actor.assertionMethod:

--- a/src/apkit/helper/inbox.py
+++ b/src/apkit/helper/inbox.py
@@ -46,6 +46,8 @@ class InboxVerifier:
         keys = {}
         if isinstance(actor.publicKey, CryptographicKey):
             keys[actor.publicKey.id] = actor.publicKey.publicKeyPem
+        elif "publicKeyPem" in actor.publicKey:
+            keys[actor.publicKey["id"]] = actor.publicKey["publicKeyPem"]
         if actor.assertionMethod:
             for method in actor.assertionMethod:
                 if isinstance(method, Multikey):


### PR DESCRIPTION
The Mastodon servers I use send an Actor response that is somehow different from what apkit expects: `actor.publicKey` is not a `CryptographicKey` but a simple dict. 

closes #8